### PR TITLE
fix: implementar padrão de navegação Pai/Filho nas telas do módulo fi…

### DIFF
--- a/prjRH/src/main/java/telas/financeiro/ConfigurarRegrasSalariais.java
+++ b/prjRH/src/main/java/telas/financeiro/ConfigurarRegrasSalariais.java
@@ -7,16 +7,21 @@ import javax.swing.JOptionPane;
 
 
 public class ConfigurarRegrasSalariais extends javax.swing.JFrame {
-    
-    
+
+    private javax.swing.JFrame menuPai;
     private FinanceiroController controller;
     
    
     public ConfigurarRegrasSalariais() {
-        initComponents(); 
+        initComponents();
         this.controller = ControllerManager.getFinanceiroController();
         configurarTela();
-        carregarValoresAtuais(); 
+        carregarValoresAtuais();
+    }
+
+    public ConfigurarRegrasSalariais(javax.swing.JFrame menuPai) {
+        this();
+        this.menuPai = menuPai;
     }
     
     
@@ -293,6 +298,9 @@ public class ConfigurarRegrasSalariais extends javax.swing.JFrame {
     private void btnVoltarActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVoltarActionPerformed
         // TODO add your handling code here:
         this.dispose();
+        if (menuPai != null) {
+            menuPai.setVisible(true);
+        }
     }//GEN-LAST:event_btnVoltarActionPerformed
 
     private void txtPercentualINSSActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_txtPercentualINSSActionPerformed

--- a/prjRH/src/main/java/telas/financeiro/GerarFolhaPagamento.java
+++ b/prjRH/src/main/java/telas/financeiro/GerarFolhaPagamento.java
@@ -10,8 +10,8 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 
 public class GerarFolhaPagamento extends javax.swing.JFrame {
-    
-    
+
+    private javax.swing.JFrame menuPai;
     private FinanceiroController controller;
     private DefaultTableModel modeloTabela;
     private FolhaPagamento folhaAtual;
@@ -20,6 +20,11 @@ public class GerarFolhaPagamento extends javax.swing.JFrame {
         initComponents();
         this.controller = ControllerManager.getFinanceiroController();
         configurarTela();
+    }
+
+    public GerarFolhaPagamento(javax.swing.JFrame menuPai) {
+        this();
+        this.menuPai = menuPai;
     }
     
     private void configurarTela() {
@@ -282,6 +287,9 @@ public class GerarFolhaPagamento extends javax.swing.JFrame {
     private void btnVoltarActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVoltarActionPerformed
         // TODO add your handling code here:
         this.dispose();
+        if (menuPai != null) {
+            menuPai.setVisible(true);
+        }
     }//GEN-LAST:event_btnVoltarActionPerformed
 
     

--- a/prjRH/src/main/java/telas/financeiro/ListagemFuncionarios.java
+++ b/prjRH/src/main/java/telas/financeiro/ListagemFuncionarios.java
@@ -21,6 +21,11 @@ public class ListagemFuncionarios extends javax.swing.JFrame {
         configurarTela();
         carregarFuncionarios();
     }
+
+    public ListagemFuncionarios(javax.swing.JFrame menuPai) {
+        this();
+        this.menuPai = menuPai;
+    }
     
     private void configurarTela() {
         setTitle("Listagem de Funcionários");
@@ -208,6 +213,9 @@ public class ListagemFuncionarios extends javax.swing.JFrame {
     private void btnVoltarActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVoltarActionPerformed
         // TODO add your handling code here:
         this.dispose();
+        if (menuPai != null) {
+            menuPai.setVisible(true);
+        }
     }//GEN-LAST:event_btnVoltarActionPerformed
 
     

--- a/prjRH/src/main/java/telas/financeiro/VisualizarContracheques.java
+++ b/prjRH/src/main/java/telas/financeiro/VisualizarContracheques.java
@@ -12,8 +12,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class VisualizarContracheques extends javax.swing.JFrame {
-    
-    
+
+    private javax.swing.JFrame menuPai;
     private FinanceiroController controller;
     
     public VisualizarContracheques() {
@@ -21,6 +21,11 @@ public class VisualizarContracheques extends javax.swing.JFrame {
         this.controller = ControllerManager.getFinanceiroController();
         configurarTela();
         carregarFuncionarios();
+    }
+
+    public VisualizarContracheques(javax.swing.JFrame menuPai) {
+        this();
+        this.menuPai = menuPai;
     }
     
     private void configurarTela() {
@@ -383,6 +388,9 @@ public class VisualizarContracheques extends javax.swing.JFrame {
     private void btnVoltarActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVoltarActionPerformed
         // TODO add your handling code here:
         this.dispose();
+        if (menuPai != null) {
+            menuPai.setVisible(true);
+        }
     }//GEN-LAST:event_btnVoltarActionPerformed
 
     


### PR DESCRIPTION
…nanceiro

Corrige o problema de navegação onde o menu não reaparecia ao clicar em "Voltar" nas telas filhas.

Alterações realizadas:
- ListagemFuncionarios: adicionado construtor que recebe menuPai e corrigido botão Voltar
- ConfigurarRegrasSalariais: adicionado atributo menuPai, construtor e corrigido botão Voltar
- GerarFolhaPagamento: adicionado atributo menuPai, construtor e corrigido botão Voltar
- VisualizarContracheques: adicionado atributo menuPai, construtor e corrigido botão Voltar

Todas as telas agora implementam corretamente o padrão:
1. Atributo privado menuPai do tipo JFrame
2. Construtor padrão (para compatibilidade com NetBeans)
3. Construtor que recebe menuPai e chama this()
4. Botão Voltar que executa dispose() e restaura menuPai.setVisible(true)